### PR TITLE
Support OnTap callback for dropdown

### DIFF
--- a/lib/custom_dropdown.dart
+++ b/lib/custom_dropdown.dart
@@ -224,6 +224,7 @@ class _CustomDropdownState extends State<CustomDropdown> {
           ),
           /* child: _DropDownField(
             controller: widget.controller,
+            onTap: showCallback,
             style: selectedStyle,
             borderRadius: widget.borderRadius,
             borderSide: widget.borderSide,

--- a/lib/custom_dropdown.dart
+++ b/lib/custom_dropdown.dart
@@ -51,10 +51,13 @@ class CustomDropdown extends StatefulWidget {
   // ignore: library_private_types_in_public_api
   final _ListItemBuilder? listItemBuilder;
 
+  final VoidCallback? onTap;
+  
   CustomDropdown({
     Key? key,
     required this.items,
     required this.controller,
+    this.onTap, 
     this.hintText,
     this.hintStyle,
     this.selectedStyle,
@@ -91,6 +94,7 @@ class CustomDropdown extends StatefulWidget {
     Key? key,
     required this.items,
     required this.controller,
+    this.onTap, 
     this.hintText,
     this.hintStyle,
     this.listItemBuilder,
@@ -204,7 +208,12 @@ class _CustomDropdownState extends State<CustomDropdown> {
         return CompositedTransformTarget(
           link: layerLink,
           child: GestureDetector(
-            onTap: showCallback,
+            onTap: () {
+              if (widget.onTap != null) {
+                widget.onTap!();
+              }
+              showCallback();
+            },
             child: Container(
               height: 40,
               child: Text(
@@ -215,7 +224,6 @@ class _CustomDropdownState extends State<CustomDropdown> {
           ),
           /* child: _DropDownField(
             controller: widget.controller,
-            onTap: showCallback,
             style: selectedStyle,
             borderRadius: widget.borderRadius,
             borderSide: widget.borderSide,


### PR DESCRIPTION
I needed to access the onTap function to scroll into view for my app. This minor change allows access to the OnTap callback of the underlying Dropdown when calling the functions